### PR TITLE
Add security headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,5 @@ coverage==6.3.2
 httpie==3.2.1
 
 Flask-Talisman
+
+Flask-Cors

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,5 @@ coverage==6.3.2
 
 # Utilities
 httpie==3.2.1
+
+Flask-Talisman

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -8,10 +8,12 @@ import sys
 from flask import Flask
 from service import config
 from service.common import log_handlers
+from flask_talisman import Talisman
 
 # Create Flask application
 app = Flask(__name__)
 app.config.from_object(config)
+talisman = Talisman(app)
 
 # Import the routes After the Flask app is created
 # pylint: disable=wrong-import-position, cyclic-import, wrong-import-order

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -9,11 +9,13 @@ from flask import Flask
 from service import config
 from service.common import log_handlers
 from flask_talisman import Talisman
+from flask_cors import CORS
 
 # Create Flask application
 app = Flask(__name__)
 app.config.from_object(config)
 talisman = Talisman(app)
+CORS(app)
 
 # Import the routes After the Flask app is created
 # pylint: disable=wrong-import-position, cyclic-import, wrong-import-order

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -175,3 +175,10 @@ class TestAccountService(TestCase):
         }
         for key, value in headers.items():
             self.assertEqual(response.headers.get(key), value)
+
+    def test_cors_security(self):
+        """It should return a CORS header"""
+        response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Check for the CORS header
+        self.assertEqual(response.headers.get('Access-Control-Allow-Origin'), '*')

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -12,12 +12,14 @@ from tests.factories import AccountFactory
 from service.common import status  # HTTP Status Codes
 from service.models import db, Account, init_db
 from service.routes import app
+from service import talisman
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/postgres"
 )
 
 BASE_URL = "/accounts"
+HTTPS_ENVIRON = {'wsgi.url_scheme': 'https'}
 
 
 ######################################################################
@@ -34,6 +36,7 @@ class TestAccountService(TestCase):
         app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
         app.logger.setLevel(logging.CRITICAL)
         init_db(app)
+        talisman.force_https = False
 
     @classmethod
     def tearDownClass(cls):
@@ -159,3 +162,16 @@ class TestAccountService(TestCase):
         account = self._create_accounts(1)[0]
         resp = self.client.delete(f"{BASE_URL}/{account.id}")
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_security_headers(self):
+        """It should return security headers"""
+        response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        headers = {
+            'X-Frame-Options': 'SAMEORIGIN',
+            'X-Content-Type-Options': 'nosniff',
+            'Content-Security-Policy': 'default-src \'self\'; object-src \'none\'',
+            'Referrer-Policy': 'strict-origin-when-cross-origin'
+        }
+        for key, value in headers.items():
+            self.assertEqual(response.headers.get(key), value)


### PR DESCRIPTION
Implemented Flask-Talisman for HTTP security headers and Flask-Cors for cross-origin support. Disabled forced HTTPS in the test environment to allow local test execution. Verified that all unit tests pass and headers appear in curl output. CI pipeline is triggered.
